### PR TITLE
Use Sites instead of microsite configuration to specify request domain based urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Each backend is a key under `SCORM_PLAYER_BACKENDS` and should provide a `"name"
 
 Nginx (or other front-end web server) must be configured to serve SCORM content. See the file [`docs/nginx_configuration.md`](docs/nginx_configuration.md) for edits that need to be made to your `/etc/nginx/sites-enabled/lms` and `/etc/nginx/sites-enabled/cms` files to serve your SCORM content.
 
+# `Site` configuration
+
+The SCORM XBlock is `Site`-aware.  Student views of XBlock instances will use the current `Site` domain as the LMS endpoint URL root.  Make sure your default any other `Site`s are configured with the proper domain.
+A common mistake would be to leave the default `Site` domain as `"example.com"`.  Update your default `Site` domain via `/admin/sites/site`.
+
 # Usage
 * In Studio, add `scormxblock` to the list of advanced modules in the advanced settings of a course.
 * Add a 'scorm' component to your Unit. 

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -17,7 +17,11 @@ from xblock.fields import Scope, String, Integer, Boolean, Float
 from xblock.fragment import Fragment
 
 from openedx.core.lib.xblock_utils import add_staff_markup
-from microsite_configuration import microsite
+try:
+    from openedx.core.djangoapps.theming.helpers import get_current_site
+except ImportError:
+    from django.contrib.sites.shortcuts import get_current_site
+    from request_cache.middleware import RequestCache
 
 from mako.template import Template as MakoTemplate
 
@@ -177,9 +181,16 @@ class ScormXBlock(XBlock):
     def student_view(self, context=None, authoring=False):
         scheme = 'https' if settings.HTTPS == 'on' else 'http'
         lms_base = settings.ENV_TOKENS.get('LMS_BASE')
-        if microsite.is_request_in_microsite():
-            subdomain = microsite.get_value("domain_prefix", None) or microsite.get_value('microsite_config_key')
-            lms_base = "{}.{}".format(subdomain, lms_base) 
+
+        try:
+            site = get_current_site()  # theming.helpers
+        except TypeError:
+            site = get_current_site(RequestCache.get_current_request())  # django.contrib.site
+        try:            
+            lms_base = site.domain
+        except AttributeError:
+            lms_base = settings.ENV_TOKENS("LMS_BASE")    
+
         scorm_player_url = ""
 
         if self.scorm_player == 'SCORM_PKG_INTERNAL':

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -53,6 +53,7 @@ else:
     scorm_storage_instance = scorm_storage_class()
 
 AVAIL_ENCODINGS = encodings.aliases.aliases
+DEFAULT_SITE_DOMAIN = "example.com"
 
 class ScormXBlock(XBlock):
 
@@ -186,8 +187,9 @@ class ScormXBlock(XBlock):
             site = get_current_site()  # theming.helpers
         except TypeError:
             site = get_current_site(RequestCache.get_current_request())  # django.contrib.site
-        try:            
-            lms_base = site.domain
+        try:  
+            # guard against unset/default Site domain           
+            lms_base = site.domain if str(site.domain) != DEFAULT_SITE_DOMAIN else settings.ENV_TOKENS.get("LMS_BASE")
         except AttributeError:
             lms_base = settings.ENV_TOKENS("LMS_BASE")    
 


### PR DESCRIPTION
Use more up to date approach setting LMS base url for get/set calls based on domain matching Django `Site`.  Deprecated `microsite_configuration`-based approach.