### PR TITLE
Add window beforeunload confirmation dialog and warning text

### DIFF
--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -22,7 +22,7 @@ for item in list({player_config}.items()):
     <div class="scorm_description">{self.description}
         % if self.display_type == 'iframe':
              <p class="warning">
-                <span class="icon fa fa-warning">Please complete work in the module popup window or tab before navigating away from this page to avoid losing work.</span>
+                <span class="icon fa fa-warning">ATTENTION: Please complete your course work in the module popup window/tab before navigating away from this page to avoid losing your course progress.</span>
             </p>
         % endif
         <div class="scorm_launch"><button id="scorm-launch-{self.url_name}">Launch module</button></div>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -20,10 +20,10 @@ for item in list({player_config}.items()):
 <div class="scormxblock_block">
     <h3 class="scorm_name">{self.display_name} (External Resource) <span class="scorm_weight">{self.weight} points possible</span></h3>
     <div class="scorm_description">{self.description}
-         <p class="warning">
-            <span class="icon fa fa-warning">ATTENTION: Please complete your course work in the module popup window/tab before navigating away from this page to avoid losing your course progress.</span>
-        </p>
-
+         <div class="alert alert-warning" role="alert">
+            <span class="icon icon-alert fa fa fa-warning" aria-hidden="true"></span>
+            <div class="message-content">ATTENTION: Please complete your course work in the module popup window/tab before navigating away from this page to avoid losing your course progress.</div>
+        </div>
         <div class="scorm_launch"><button id="scorm-launch-{self.url_name}">Launch module</button></div>
     </div>
 

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -20,11 +20,10 @@ for item in list({player_config}.items()):
 <div class="scormxblock_block">
     <h3 class="scorm_name">{self.display_name} (External Resource) <span class="scorm_weight">{self.weight} points possible</span></h3>
     <div class="scorm_description">{self.description}
-        % if self.display_type == 'iframe':
-             <p class="warning">
-                <span class="icon fa fa-warning">ATTENTION: Please complete your course work in the module popup window/tab before navigating away from this page to avoid losing your course progress.</span>
-            </p>
-        % endif
+         <p class="warning">
+            <span class="icon fa fa-warning">ATTENTION: Please complete your course work in the module popup window/tab before navigating away from this page to avoid losing your course progress.</span>
+        </p>
+
         <div class="scorm_launch"><button id="scorm-launch-{self.url_name}">Launch module</button></div>
     </div>
 

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -1,9 +1,16 @@
 <%!
 import cgi
+from openedx.core.djangolib.markup import HTML
 %>
 <%  
 	player_config_attrs = ''
 %>	
+
+<%block name="head_extra">
+    <script language="javascript">
+
+    </script>
+</%block>
 
 <% 
 for item in list({player_config}.items()):
@@ -13,6 +20,11 @@ for item in list({player_config}.items()):
 <div class="scormxblock_block">
     <h3 class="scorm_name">{self.display_name} (External Resource) <span class="scorm_weight">{self.weight} points possible</span></h3>
     <div class="scorm_description">{self.description}
+        % if self.display_type == 'iframe':
+             <p class="warning">
+                <span class="icon fa fa-warning">Please complete work in the module popup window or tab before navigating away from this page to avoid losing work.</span>
+            </p>
+        % endif
         <div class="scorm_launch"><button id="scorm-launch-{self.url_name}">Launch module</button></div>
     </div>
 

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -20,9 +20,9 @@ for item in list({player_config}.items()):
 <div class="scormxblock_block">
     <h3 class="scorm_name">{self.display_name} (External Resource) <span class="scorm_weight">{self.weight} points possible</span></h3>
     <div class="scorm_description">{self.description}
-         <div class="alert alert-warning" role="alert">
+         <div class="alert-warning" role="alert">
             <span class="icon icon-alert fa fa fa-warning" aria-hidden="true"></span>
-            <div class="message-content">ATTENTION: Please complete your course work in the module popup window/tab before navigating away from this page to avoid losing your course progress.</div>
+            <span class="message-content">ATTENTION: Please complete your course work in the module popup window/tab before navigating away from this page to avoid losing your course progress.</span>
         </div>
         <div class="scorm_launch"><button id="scorm-launch-{self.url_name}">Launch module</button></div>
     </div>

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -87,6 +87,7 @@ function ScormXBlock_${block_id}(runtime, element) {
           event.preventDefault();
           // the below is mostly unsupported by browsers so we will probably get the default confirmation dialog
           return event.returnValue = "Leaving this page while the module popup is open can result in losing current or further progress in the module.";
+        }
       }
       catch (e) {
         if (e instanceof TypeError) {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -79,14 +79,32 @@ function ScormXBlock_${block_id}(runtime, element) {
     API = new SCORM_API();
     console.log("Initial SCORM data...");
 
+    const beforeUnloadListener = (event) => {
+      // since to assign this directly to playerWin w/o being able to use addEventListener,
+      // means we can't capture, we don't know if player may actually try to close its popup window while this is firing
+      try {
+        if (event.currentTarget.frames[0].frames.length > 0) {  // host iframe has opened popups
+          event.preventDefault();
+          // the below is mostly unsupported by browsers so we will probably get the default confirmation dialog
+          return event.returnValue = "Leaving this page while the module popup is open can result in losing current or further progress in the module.";
+      }
+      catch (e) {
+        if (e instanceof TypeError) {
+          return;
+        }
+      }
+    };
+
     //post message with data to player frame
     //player must be in an iframe and not a popup due to limitations in Internet Explorer's postMessage implementation
     launch_btn_${block_id} = $('#scorm-launch-${block_id}');
     host_frame_${block_id} = $('#scormxblock-${block_id}');
     host_frame_${block_id}.data('csrftoken', $.cookie('csrftoken'));
+    display_type = host_frame_${block_id}.data('display_type');
+
     launch_btn_${block_id}.on('click', function() {
       playerWin = null;
-      if (host_frame_${block_id}.data('display_type') == 'iframe') {
+      if (display_type == 'iframe') {
         host_frame_${block_id}.css('height', host_frame_${block_id}.data('display_height') + 'px');
       }
       host_frame_${block_id}.attr('src',host_frame_${block_id}.data('player_url'));
@@ -95,14 +113,12 @@ function ScormXBlock_${block_id}(runtime, element) {
         playerWin.postMessage(host_frame_${block_id}.data(), '*');
         launch_btn_${block_id}.attr('disabled','true');
 
+        playerWin.onbeforeunload = beforeUnloadListener; // addEventListener doesn't work here, cross-browser
         playerWin.ssla.ssla.scorm.events.postFinish.add(function() {
-        launch_btn_${block_id}.removeAttr('disabled');
+            launch_btn_${block_id}.removeAttr('disabled');
+              playerWin.onbeforeunload = null;
         })
-
       });
-      
-
-    });    
-
+    });
   });
 }


### PR DESCRIPTION
Don't allow unload of window without confirmation. In most browsers, this will just be a generic beforeunload confirmation dialog.
Add warning text above the SCORM content.